### PR TITLE
fix dA function prompt for the new same-domain scheme

### DIFF
--- a/functions/deviantArt.js
+++ b/functions/deviantArt.js
@@ -9,7 +9,7 @@ module.exports = {
     "noMention": true,
     "noMentionLikelihood": 100,
     "prompts": [
-      "(http(s)?:\/\/.*deviantart.com\/art\/[^ ]+)"
+      /(https?:\/\/[^\s\/]*deviantart.com\/[^\s\/]+\/art\/[^\s]+)/gi
     ],
     "role": "All",
     "channels": [


### PR DESCRIPTION
Turned prompt to actual regex since [app.js#L191](https://github.com/Jykinturah/ducky-ink/blob/bebc8567077cd5d3c7501a0df98f3706a41673b8/app.js#L191) expands `[^ ]` to `[^ ?]`, which shouldn't be an issue but can't hurt either just to be sure with URL parameters.

Tested to work, hasn't exploded.