### PR TITLE
embed dA function reply to avoid spam with long URLs

### DIFF
--- a/functions/deviantArt.js
+++ b/functions/deviantArt.js
@@ -26,7 +26,7 @@ module.exports = {
 
         bot.helpers.getMETA(link[0], function(meta) {
           if (meta.image) {
-            message.reply(chance.pickone(bot.soul('deviantArtResponses')) + " " + meta.image);
+            message.reply(chance.pickone(bot.soul('deviantArtResponses')), {embed: {image: {url: meta.image}}});
           }
         });
       }


### PR DESCRIPTION
Lot of quacking for those. Going to get a sore throat.

Direct links can still be copied by right click or opening in the browser.

Tested to work, hasn't exploded.